### PR TITLE
excess default value quoting for functions

### DIFF
--- a/DB/Pool/postgresql.js
+++ b/DB/Pool/postgresql.js
@@ -118,6 +118,7 @@ module.exports = class extends require ('../Pool.js') {
     
     gen_sql_quoted_literal (s) {
         if (s == null) s = ''
+        if (/\(|\)/.test (s)) return s
         return "'" + String (s).replace(/'/g, "''") + "'"
     }
     


### PR DESCRIPTION
PostgreSQL 10.13 (Debian 10.13-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit

ALTER TABLE "users" ALTER COLUMN "uuid" SET DEFAULT 'uuid_generate_v4()'

-> ERROR:  invalid input syntax for type uuid: "uuid_generate_v4()"