### PR TITLE
VACUUM ANALYZE voc_fias_house (label gin_trgm_ops) syntax error FIX

### DIFF
--- a/DB/Pool/postgresql.js
+++ b/DB/Pool/postgresql.js
@@ -673,6 +673,10 @@ module.exports = class extends require ('../Pool.js') {
 
                 	let [, cols] = src.split (/[\(\)]/)
 
+                    cols = cols.split (/,\s*/)
+                        .map (c =>  c.match(/^(\w+)/) [0] )
+                        .join (', ')
+
                 	result.push ({sql: `VACUUM ANALYZE ${table.name} (${cols})`, params: []})
 
                 }


### PR DESCRIPTION
SELECT VERSION();
PostgreSQL 10.13 (Debian 10.13-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit

as is
VACUUM ANALYZE voc_fias_house (label gin_trgm_ops)
should be
VACUUM ANALYZE voc_fias_house (label)

syntax
https://postgrespro.ru/docs/postgrespro/10/sql-createindex
https://postgrespro.ru/docs/postgrespro/10/sql-vacuum