### PR TITLE
clickhouse logging 400 FIX

### DIFF
--- a/HTTP.js
+++ b/HTTP.js
@@ -64,7 +64,9 @@ module.exports = class {
 				x.code = rp.statusCode
 			
 				x.body = rp_body
-				
+
+				x.parent = rp.log_event
+
 				return x
 
 			}

--- a/Log/WrappedError.js
+++ b/Log/WrappedError.js
@@ -3,8 +3,10 @@ module.exports = class extends Error {
     constructor (e, o = {}) {
 
 		super (e.message)
-		
+
 		this.stack = e.stack
+
+		this.path = [o.log_meta.parent]
 		
 		for (let [k, v] of [...Object.entries ({...e, ...o})]) 
 		
@@ -14,4 +16,7 @@ module.exports = class extends Error {
 
 	}
 
+	get_sigil () {
+		return '!'
+	}
 }

--- a/Timer.js
+++ b/Timer.js
@@ -222,6 +222,8 @@ module.exports = class {
 
 				let {o, conf} = this, {log_meta} = o
 
+				if (x.parent) log_meta.parent = x.parent
+
 		    	conf.log_event (new WrappedError (x, {log_meta}))
 
 				if (this.o.stop_on_error) {


### PR DESCRIPTION
```
node:21932) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'join' of undefined
    at module.exports.transform (/var/projects/mip_testing/libs/mip/back/lib/Ext/Dia/Log/ConsoleLogger.js:14:11)
    at module.exports.write (/var/projects/mip_testing/libs/mip/back/lib/Ext/Dia/Log/ConsoleLogger.js:26:8)
    at module.exports.log_event (/var/projects/mip_testing/libs/mip/back/lib/Ext/Dia/Config.js:148:32)
    at module.exports.run (/var/projects/mip_testing/libs/mip/back/lib/Ext/Dia/Timer.js:225:13)
    at process._tickCallback (internal/process/next_tick.js:68:7)

```