### PR TITLE
add_all_cnt: adjust params for sql_cnt query

### DIFF
--- a/DB/Client.js
+++ b/DB/Client.js
@@ -160,7 +160,6 @@ module.exports = class {
     async add_all_cnt (data, def, limit, offset) {
 
         let q = this.query (def)        
-
         if (limit == undefined) limit = q.limit
         if (limit == undefined) throw 'LIMIT not set for add_all_cnt: ' + JSON.stringify (def)
 
@@ -168,10 +167,9 @@ module.exports = class {
         if (offset == undefined) offset = 0
         
         let [limited_sql, limited_params] = this.to_limited_sql_params (q.sql, q.params, limit, offset)
-
         let [all, cnt] = await Promise.all ([
         	this.select_all    (limited_sql, limited_params),
-        	this.select_scalar (q.sql_cnt, q.params),
+            this.select_scalar (q.sql_cnt, q.params_cnt),
         ])
 
         data [q.parts [0].alias] = all


### PR DESCRIPTION
Теперь при построении запроса, который считает количество записей для add_all_cnt, отрезаются не только LEFT JOIN-ы, но и параметры для них. Раньше подобный вызов приводил к ошибке:
```
let data = await db.add_all_cnt ({}, [
        { 'arbitrages' : filter },
        { 'arbitrage_documents ON arbitrage_documents.root_id = document_root_id ' : {
                casebook_queue_id: rq.casebook_queue_id
        }},
])
```
