### PR TITLE
Bugfix: deleting a VIEW via `sql: -Infinity` didn't work

### DIFF
--- a/DB/Pool.js
+++ b/DB/Pool.js
@@ -280,6 +280,8 @@ module.exports = class {
 
         for (let d of Object.values (model.table_drops)) this.normalize_model_table_name (d)
 
+        for (let d of Object.values (model.view_drops)) this.normalize_model_table_name (d)
+
 
     }
 


### PR DESCRIPTION
Couldn't delete a VIEW via:

```js
module.exports = {
    sql: -Infinity
}
```

А query with a syntax error was built:

```sql
DROP VIEW IF EXISTS ,"in_m13_status_clean_vw","in_m13_unknown_vw", ...
```