### PR TITLE
node 10.24 syntax error FIX

### DIFF
--- a/Log/Events/FS.js
+++ b/Log/Events/FS.js
@@ -10,13 +10,13 @@ module.exports = class extends Event {
 		
 		super ({category: 'f_s', ...o})
 		
-		if (this.action == 'append') this.size = 0n
+		if (this.action == 'append') this.size = BigInt (0)
 
 	}
 	
 	get_meter () {
 	
-		this.size = 0n
+		this.size = BigInt (0)
 	
 		let me = this
 


### PR DESCRIPTION
[mg@vm Dia (eslint)]$ node -v
v10.24.1
[mg@vm Dia (eslint)]$ cat /var/projects/mil/test.js
let ok = new BigInt (0)
lex fail = 0n
[mg@vm Dia (eslint)]$ node  /var/projects/mil/test.js
/var/projects/mil/test.js:2
lex fail = 0n
    ^^^^

SyntaxError: Unexpected identifier
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
