### PR TITLE
Исправил обработку исключений брошенные в тригере

### DIFF
--- a/DB/Client/postgresql.js
+++ b/DB/Client/postgresql.js
@@ -79,7 +79,7 @@ class PgClient extends Dia.DB.Client {
 
 					cursor.close ()
 
-					if (err) return fail (Error (err))
+					if (err) return fail (err)
 
 					if (!isPartial && rows.length > maxRows) return fail (Error (maxRows + ' rows limit exceeded. Plesae fix the request or consider using select_stream instead of select_all'))
 


### PR DESCRIPTION
Текст ошибки брошенная в триггере БД postgresql (RAISE '#_#....')  не передавалась клиенту.