### PR TITLE
Ignore empty keys when upsert data

### DIFF
--- a/DB/Client/postgresql.js
+++ b/DB/Client/postgresql.js
@@ -200,6 +200,8 @@ class PgClient extends Dia.DB.Client {
             
             outer: for (let ix of Object.values (keys)) {
 
+                if (!ix) continue
+
                 if (!ix.match (/^\s*CREATE\s*UNIQUE/i)) continue
                 
                 let cols = ix.slice (1 + ix.indexOf ('('), ix.lastIndexOf (')'))


### PR DESCRIPTION
If delete key with -Infinity value, then it remains in the table as null and next condition failed with error 'cannot read property 'match' of null'