### PR TITLE
semgrep calm down FP action not pinned

### DIFF
--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/checkout@v2
     - name: nodejsscan scan
       id: njsscan
+      # nosemrep yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned
       uses: ajinabraham/njsscan-action@v7
       with:
         args: '. -w'


### PR DESCRIPTION
`podman run --rm -v "$PWD:/src" docker.io/returntocorp/semgrep:1.31.2 semgrep --strict --config p/default  --no-git-ignore  /src`